### PR TITLE
Update for MonadFail in GHC 8.8

### DIFF
--- a/Text/JSON5.hs
+++ b/Text/JSON5.hs
@@ -138,9 +138,11 @@ instance MonadPlus Result where
 
 instance Monad Result where
   return x      = Ok x
-  fail x        = Error x
   Ok a >>= f    = f a
   Error x >>= _ = Error x
+
+instance MonadFail Result where
+  fail x        = Error x
 
 mkError :: String -> Result a
 mkError s = Error s

--- a/Text/JSON5/String.hs
+++ b/Text/JSON5/String.hs
@@ -57,10 +57,12 @@ instance A.Applicative GetJSON where
 
 instance Monad GetJSON where
   return x        = GetJSON (\s -> Right (x,s))
-  fail x          = GetJSON (\_ -> Left x)
   GetJSON m >>= f = GetJSON (\s -> case m s of
                                      Left err -> Left err
                                      Right (a,s1) -> un (f a) s1)
+
+instance MonadFail GetJSON where
+  fail x          = GetJSON (\_ -> Left x)
 
 -- | Run a JSON5 reader on an input String, returning some Haskell value.
 -- All input will be consumed.


### PR DESCRIPTION
Fail does not exist anymore in `Monad`:
https://downloads.haskell.org/~ghc/8.8.1/docs/html/users_guide/8.8.1-notes.html#base-library
> The fail method of Monad has been removed in favor of the method of the same name in the MonadFail class.